### PR TITLE
Use Google account ID in OAuth adapter

### DIFF
--- a/src/auth/PhutilGoogleAuthAdapter.php
+++ b/src/auth/PhutilGoogleAuthAdapter.php
@@ -14,7 +14,7 @@ final class PhutilGoogleAuthAdapter extends PhutilOAuthAuthAdapter {
   }
 
   public function getAccountID() {
-    return $this->getAccountEmail();
+    return $this->getOAuthAccountData('id');
   }
 
   public function getAccountEmail() {


### PR DESCRIPTION
As recommended by Google, the account ID is preferred to the email
address as the identifier since email addresses can change. This allows
maintaining the account linking after we change our email domain to
endlessos.org. Unfortunately, it will make all the existing links
invalid and phabricator only allows a single Google auth token to be
linked to an account. The existing links will need to be changed in the
database when this lands so users aren't locked out of their phabricator
accounts.

I tested this extensively on the dev phabricator instance and it does what I expect. We need to rewrite the database entries at the same time, but I've prepared that in the phabricator task.

https://phabricator.endlessm.com/T29811